### PR TITLE
ignore SIGPIPE on Windows

### DIFF
--- a/test/oatpp-openssl/tests.cpp
+++ b/test/oatpp-openssl/tests.cpp
@@ -13,7 +13,9 @@ namespace {
 void runTests() {
 
   /* ignore SIGPIPE */
-  std::signal(SIGPIPE, SIG_IGN);
+  #if !(defined(WIN32) || defined(_WIN32))
+    std::signal(SIGPIPE, SIG_IGN);
+  #endif
 
   {
 


### PR DESCRIPTION
fixes build errors