### PR TITLE
Draft for reloadable configuration (Addressing oatpp/oatpp#483).

### DIFF
--- a/src/oatpp-openssl/Config.cpp
+++ b/src/oatpp-openssl/Config.cpp
@@ -63,10 +63,15 @@ void Config::addContextConfigurer(const std::shared_ptr<configurer::ContextConfi
   m_contextConfigs.push_back(contextConfigurer);
 }
 
-void Config::configureContext(SSL_CTX* ctx) const {
+void Config::configureContext(const std::shared_ptr<SSL_CTX> &ctx) {
+  m_ctx = ctx;
   for(auto& c : m_contextConfigs) {
-    c->configure(ctx);
+    c->configure(ctx.get());
   }
 }
-  
+
+const std::shared_ptr<SSL_CTX> &Config::getCtx() const {
+  return m_ctx;
+}
+
 }}

--- a/src/oatpp-openssl/Config.hpp
+++ b/src/oatpp-openssl/Config.hpp
@@ -34,6 +34,7 @@ namespace oatpp { namespace openssl {
 class Config {
 private:
   std::list<std::shared_ptr<configurer::ContextConfigurer>> m_contextConfigs;
+  std::shared_ptr<SSL_CTX> m_ctx;
 public:
 
   Config();
@@ -51,7 +52,8 @@ public:
   void clearContextConfigurers();
   void addContextConfigurer(const std::shared_ptr<configurer::ContextConfigurer>& contextConfigurer);
 
-  void configureContext(SSL_CTX* ctx) const;
+  void configureContext(const std::shared_ptr<SSL_CTX> &ctx);
+  const std::shared_ptr<SSL_CTX> &getCtx() const;
 
 };
   

--- a/src/oatpp-openssl/Connection.cpp
+++ b/src/oatpp-openssl/Connection.cpp
@@ -247,13 +247,17 @@ int Connection::BioRead(BIO* bio, char* data, int size) {
 
 }
 
-Connection::Connection(SSL* ssl, const std::shared_ptr<oatpp::data::stream::IOStream>& stream)
-  : m_ssl(ssl)
+Connection::Connection(const std::shared_ptr<Config> &config, const std::shared_ptr<oatpp::data::stream::IOStream>& stream)
+  : m_config(config)
   , m_rbio(BIO_new(getBioMethod()))
   , m_wbio(BIO_new(getBioMethod()))
   , m_stream(stream)
   , m_initialized(false)
 {
+
+  m_ssl = SSL_new(m_config->getCtx().get());
+  SSL_set_mode(m_ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
+  SSL_set_accept_state(m_ssl);
 
   BIO_set_data(m_rbio, this);
   BIO_set_data(m_wbio, this);

--- a/src/oatpp-openssl/Connection.hpp
+++ b/src/oatpp-openssl/Connection.hpp
@@ -27,6 +27,7 @@
 
 #include "oatpp/core/data/stream/Stream.hpp"
 #include "oatpp/core/data/buffer/FIFOBuffer.hpp"
+#include "oatpp-openssl/Config.hpp"
 
 #include <openssl/ssl.h>
 
@@ -71,6 +72,7 @@ private:
   BIO* m_rbio;
   BIO* m_wbio;
 private:
+  const std::shared_ptr<Config> m_config;
   std::shared_ptr<oatpp::data::stream::IOStream> m_stream;
 private:
   std::atomic<bool> m_initialized;
@@ -87,7 +89,7 @@ public:
    * @param ssl - pointer to OpenSSL ssl object;.
    * @param stream - underlying transport stream. &id:oatpp::data::stream::IOStream;.
    */
-  Connection(SSL* ssl, const std::shared_ptr<oatpp::data::stream::IOStream>& stream);
+  Connection(const std::shared_ptr<Config> &config, const std::shared_ptr<oatpp::data::stream::IOStream>& stream);
 
   /**
    * Virtual destructor.

--- a/src/oatpp-openssl/server/ConnectionProvider.hpp
+++ b/src/oatpp-openssl/server/ConnectionProvider.hpp
@@ -42,8 +42,6 @@ private:
   std::shared_ptr<oatpp::network::ServerConnectionProvider> m_streamProvider;
 private:
   void instantiateTLSServer();
-private:
-  SSL_CTX* m_ctx;
 public:
   /**
    * Constructor.
@@ -115,7 +113,13 @@ public:
    * @param connection - **MUST** be an instance of &id:oatpp::openssl::Connection;.
    */
   void invalidate(const std::shared_ptr<data::stream::IOStream>& connection) override;
-  
+
+  /**
+   * Will update the internal config and handle all new connections with it.
+   * @param config - &id:oatpp::openssl::Config;.
+   */
+  void updateConfig(const std::shared_ptr<Config>& config);
+
 };
   
 }}}


### PR DESCRIPTION
**DO NOT MERGE, UNTESTED PSEUDO-CODE-LIKE PROPOSAL**

---

`ssl_ctx_st` are now bound to their respective `Config` via shared pointers.
When creating an `Connection`, the config is passed and stored in the `Connection`, also in a shared pointer.
Thus, we have full reference counting on the `ssl_ctx_st`.
The context is automatically freed when no `Connection` exists with the config containing the context and the `ConnectionProvider` has loaded a new config.

Discussion: Since the context is now part of the config, shouldn't the code in `instantiateTLSServer` moved to `Config`? This way, SSLv23_server_method would be made easily configurable, too.