### PR TITLE
Updates to the buffered configured api

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(${OATPP_THIS_MODULE_NAME}
         oatpp-openssl/client/ConnectionProvider.hpp
         oatpp-openssl/server/ConnectionProvider.cpp
         oatpp-openssl/server/ConnectionProvider.hpp
+        oatpp-openssl/configurer/CaCertificateBundleBuffer.cpp
+        oatpp-openssl/configurer/CaCertificateBundleBuffer.hpp
         oatpp-openssl/configurer/CertificateChainBuffer.cpp
         oatpp-openssl/configurer/CertificateChainBuffer.hpp
         oatpp-openssl/configurer/CertificateChainFile.cpp
@@ -17,6 +19,8 @@ add_library(${OATPP_THIS_MODULE_NAME}
         oatpp-openssl/configurer/CertificateFile.cpp
         oatpp-openssl/configurer/CertificateFile.hpp
         oatpp-openssl/configurer/ContextConfigurer.hpp
+        oatpp-openssl/configurer/PeerCertificateVerification.cpp
+        oatpp-openssl/configurer/PeerCertificateVerification.hpp
         oatpp-openssl/configurer/PrivateKeyBuffer.cpp
         oatpp-openssl/configurer/PrivateKeyBuffer.hpp
         oatpp-openssl/configurer/PrivateKeyFile.cpp

--- a/src/oatpp-openssl/client/ConnectionProvider.cpp
+++ b/src/oatpp-openssl/client/ConnectionProvider.cpp
@@ -29,6 +29,7 @@
 #include "oatpp/network/tcp/client/ConnectionProvider.hpp"
 
 #include <openssl/crypto.h>
+#include <openssl/err.h>
 
 namespace oatpp { namespace openssl { namespace client {
 
@@ -117,6 +118,10 @@ provider::ResourceHandle<data::stream::IOStream> ConnectionProvider::get(){
   }
 
   auto ssl = SSL_new(m_ctx);
+  if(ssl == NULL) {
+      std::string openssl_err_msg = ERR_error_string(ERR_get_error(), NULL);
+      throw std::runtime_error("[oatpp::openssl::client::ConnectionProvider::get()]: Error. Could not instantiate ssl object." + openssl_err_msg);
+  }
   SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
   SSL_set_connect_state(ssl);
   SSL_set_tlsext_host_name(ssl, host->c_str());

--- a/src/oatpp-openssl/client/ConnectionProvider.cpp
+++ b/src/oatpp-openssl/client/ConnectionProvider.cpp
@@ -118,8 +118,8 @@ provider::ResourceHandle<data::stream::IOStream> ConnectionProvider::get(){
   }
 
   auto ssl = SSL_new(m_ctx);
-  if(ssl == NULL) {
-      std::string openssl_err_msg = ERR_error_string(ERR_get_error(), NULL);
+  if(ssl == nullptr) {
+      std::string openssl_err_msg = ERR_error_string(ERR_get_error(), nullptr);
       throw std::runtime_error("[oatpp::openssl::client::ConnectionProvider::get()]: Error. Could not instantiate ssl object." + openssl_err_msg);
   }
   SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);

--- a/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.cpp
+++ b/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.cpp
@@ -1,0 +1,81 @@
+/***************************************************************************
+ *
+ * Project         _____    __   ____   _      _
+ *                (  _  )  /__\ (_  _)_| |_  _| |_
+ *                 )(_)(  /(__)\  )( (_   _)(_   _)
+ *                (_____)(__)(__)(__)  |_|    |_|
+ *
+ *
+ * Copyright 2018-present, Leonid Stryzhevskyi <lganzzzo@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************************/
+
+#include "CaCertificateBundleBuffer.hpp"
+#include <openssl/ssl.h>
+
+namespace oatpp { namespace openssl { namespace configurer {
+
+static void deleteStackOfX509Info(STACK_OF(X509_INFO) *p) {
+  sk_X509_INFO_pop_free(p, X509_INFO_free);
+}
+
+CaCertificateBundleBuffer::CaCertificateBundleBuffer(const std::string& caBuffer)
+  : CaCertificateBundleBuffer::CaCertificateBundleBuffer(caBuffer.data(), caBuffer.size())
+{}
+
+CaCertificateBundleBuffer::CaCertificateBundleBuffer(const void *caBuffer, int caBufferLength)
+{
+  if (caBufferLength == 0) {
+    return;
+  }
+
+  auto buffer = std::shared_ptr<BIO>(BIO_new_mem_buf(caBuffer, caBufferLength), BIO_free);
+  if (buffer == nullptr) {
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::CertificateBuffer()]: Error. "
+                             "'buffer' == nullptr.");
+  }
+
+  m_certificates = std::shared_ptr<STACK_OF(X509_INFO)>(PEM_X509_INFO_read_bio(buffer.get(), nullptr, nullptr, nullptr), deleteStackOfX509Info);
+  if (m_certificates == nullptr)
+  {
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. "
+                             "Could not parse ca certificate buffer.");
+  }
+}
+
+void CaCertificateBundleBuffer::configure(SSL_CTX *ctx) {
+  if (m_certificates == nullptr) {
+    return;
+  }
+
+  X509_STORE* trustedCertificatesStore = SSL_CTX_get_cert_store(ctx);
+
+  if (trustedCertificatesStore == nullptr)
+  {
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. "
+                             "Could not get a trusted certificate store from the ssl ctx.");
+  }
+
+  for (int i = 0; i < sk_X509_INFO_num(m_certificates.get()); i++) {
+    auto certificate = sk_X509_INFO_value(m_certificates.get(), i)->x509;
+    if (certificate != nullptr && !X509_STORE_add_cert(trustedCertificatesStore, certificate)) {
+      throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. "
+                               "Could not add a certificate to list of trusted CAs.");
+
+    }
+  }
+}
+
+}}}

--- a/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.hpp
+++ b/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.hpp
@@ -22,8 +22,8 @@
  *
  ***************************************************************************/
 
-#ifndef oatpp_openssl_configurer_CertificateBuffer_hpp
-#define oatpp_openssl_configurer_CertificateBuffer_hpp
+#ifndef oatpp_openssl_configurer_CaCertificateBuffer_hpp
+#define oatpp_openssl_configurer_CaCertificateBuffer_hpp
 
 #include "ContextConfigurer.hpp"
 
@@ -32,21 +32,21 @@
 namespace oatpp { namespace openssl { namespace configurer {
 
 /**
- * Context configurer for certificate file.
+ * Context configurer for setting trusted Certificate Authorities (CA's) for the TLS connection
  * @extends &id:oatpp::openssl::configurer::ContextConfigurer;.
  */
-class CertificateBuffer : public ContextConfigurer {
+class CaCertificateBundleBuffer : public ContextConfigurer {
 private:
-  std::shared_ptr<X509> m_certificate;
+  std::shared_ptr<STACK_OF(X509_INFO)> m_certificates;
 public:
 
   /**
    * Constructor.
-   * @param certificateBuffer
-   * @param certificateBufferLength
+   * @param certificateBuffer PEM formatted buffer containing one or more certificates
+   * @param certificateBufferLength length of buffer in bytes (passing 0 is interpreted as a no-op)
    */
-  CertificateBuffer(const void *certificateBuffer, int certificateBufferLength);
-  CertificateBuffer(const std::string& certificateBuffer);
+  CaCertificateBundleBuffer(const void *certificateBuffer, int certificateBufferLength);
+  CaCertificateBundleBuffer(const std::string& certificateBuffer);
 
   void configure(SSL_CTX* ctx) override;
 
@@ -54,4 +54,4 @@ public:
 
 }}}
 
-#endif // oatpp_openssl_configurer_CertificateBuffer_hpp
+#endif // oatpp_openssl_configurer_CaCertificateBuffer_hpp

--- a/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.hpp
+++ b/src/oatpp-openssl/configurer/CaCertificateBundleBuffer.hpp
@@ -46,7 +46,7 @@ public:
    * @param certificateBufferLength length of buffer in bytes (passing 0 is interpreted as a no-op)
    */
   CaCertificateBundleBuffer(const void *certificateBuffer, int certificateBufferLength);
-  CaCertificateBundleBuffer(const std::string& certificateBuffer);
+  CaCertificateBundleBuffer(const oatpp::String& certificateBuffer);
 
   void configure(SSL_CTX* ctx) override;
 

--- a/src/oatpp-openssl/configurer/CertificateBuffer.cpp
+++ b/src/oatpp-openssl/configurer/CertificateBuffer.cpp
@@ -26,8 +26,15 @@
 
 namespace oatpp { namespace openssl { namespace configurer {
 
+CertificateBuffer::CertificateBuffer(const std::string& certificateBuffer)
+  : CertificateBuffer::CertificateBuffer(certificateBuffer.data(), certificateBuffer.size())
+{}
+
 CertificateBuffer::CertificateBuffer(const void *certificateBuffer, int certificateBufferLength)
 {
+  if (certificateBufferLength == 0) {
+    return;
+  }
   auto buffer = std::shared_ptr<BIO>(BIO_new_mem_buf(certificateBuffer, certificateBufferLength), BIO_free);
   m_certificate = std::shared_ptr<X509>(PEM_read_bio_X509(buffer.get(), nullptr, nullptr, nullptr), X509_free);
   if (m_certificate == nullptr) {
@@ -37,6 +44,9 @@ CertificateBuffer::CertificateBuffer(const void *certificateBuffer, int certific
 }
 
 void CertificateBuffer::configure(SSL_CTX *ctx) {
+  if (m_certificate == nullptr) {
+    return;
+  }
   if (SSL_CTX_use_certificate(ctx, m_certificate.get()) <= 0) {
     throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. "
                              "Call to 'SSL_CTX_use_certificate' failed.");

--- a/src/oatpp-openssl/configurer/CertificateBuffer.cpp
+++ b/src/oatpp-openssl/configurer/CertificateBuffer.cpp
@@ -22,12 +22,13 @@
  *
  ***************************************************************************/
 
+#include <openssl/err.h>
 #include "CertificateBuffer.hpp"
 
 namespace oatpp { namespace openssl { namespace configurer {
 
-CertificateBuffer::CertificateBuffer(const std::string& certificateBuffer)
-  : CertificateBuffer::CertificateBuffer(certificateBuffer.data(), certificateBuffer.size())
+CertificateBuffer::CertificateBuffer(const oatpp::String& certificateBuffer)
+  : CertificateBuffer::CertificateBuffer(certificateBuffer->data(), certificateBuffer->size())
 {}
 
 CertificateBuffer::CertificateBuffer(const void *certificateBuffer, int certificateBufferLength)
@@ -36,10 +37,15 @@ CertificateBuffer::CertificateBuffer(const void *certificateBuffer, int certific
     return;
   }
   auto buffer = std::shared_ptr<BIO>(BIO_new_mem_buf(certificateBuffer, certificateBufferLength), BIO_free);
+  if (buffer == nullptr) {
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::CertificateBuffer()]: Error. BIO_new_mem_buf(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
+  }
+
   m_certificate = std::shared_ptr<X509>(PEM_read_bio_X509(buffer.get(), nullptr, nullptr, nullptr), X509_free);
   if (m_certificate == nullptr) {
-    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::CertificateBuffer()]: Error. "
-                             "'m_certificate' == nullptr.");
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::CertificateBuffer()]: Error. PEM_read_bio_X509(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
   }
 }
 
@@ -48,8 +54,8 @@ void CertificateBuffer::configure(SSL_CTX *ctx) {
     return;
   }
   if (SSL_CTX_use_certificate(ctx, m_certificate.get()) <= 0) {
-    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. "
-                             "Call to 'SSL_CTX_use_certificate' failed.");
+    throw std::runtime_error("[oatpp::openssl::configurer::CertificateBuffer::configure()]: Error. SSL_CTX_use_certificate(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
   }
 }
 

--- a/src/oatpp-openssl/configurer/CertificateBuffer.hpp
+++ b/src/oatpp-openssl/configurer/CertificateBuffer.hpp
@@ -46,7 +46,7 @@ public:
    * @param certificateBufferLength
    */
   CertificateBuffer(const void *certificateBuffer, int certificateBufferLength);
-  CertificateBuffer(const std::string& certificateBuffer);
+  CertificateBuffer(const oatpp::String& certificateBuffer);
 
   void configure(SSL_CTX* ctx) override;
 

--- a/src/oatpp-openssl/configurer/CertificateChainBuffer.hpp
+++ b/src/oatpp-openssl/configurer/CertificateChainBuffer.hpp
@@ -37,15 +37,19 @@ namespace oatpp { namespace openssl { namespace configurer {
  */
 class CertificateChainBuffer : public ContextConfigurer {
 private:
-    std::shared_ptr<X509> m_chainOfCertificates;
+    std::shared_ptr<STACK_OF(X509_INFO)> m_certificates;
 public:
 
   /**
    * Constructor.
    * @param certificateChainBuffer
    * @param certificateChainBufferLength
+   *
+   * The first certificate in [certificateChainBuffer] is considered the leaf certificate and the remaining are
+   * considered intermediate ca certificates.
    */
   CertificateChainBuffer(const void *certificateChainBuffer, int certificateChainBufferLength);
+  CertificateChainBuffer(const std::string& certificateChainBuffer);
 
   void configure(SSL_CTX* ctx) override;
 

--- a/src/oatpp-openssl/configurer/CertificateChainBuffer.hpp
+++ b/src/oatpp-openssl/configurer/CertificateChainBuffer.hpp
@@ -49,7 +49,7 @@ public:
    * considered intermediate ca certificates.
    */
   CertificateChainBuffer(const void *certificateChainBuffer, int certificateChainBufferLength);
-  CertificateChainBuffer(const std::string& certificateChainBuffer);
+  CertificateChainBuffer(const oatpp::String& certificateChainBuffer);
 
   void configure(SSL_CTX* ctx) override;
 

--- a/src/oatpp-openssl/configurer/PeerCertificateVerification.cpp
+++ b/src/oatpp-openssl/configurer/PeerCertificateVerification.cpp
@@ -22,36 +22,28 @@
  *
  ***************************************************************************/
 
-#ifndef oatpp_openssl_configurer_CertificateBuffer_hpp
-#define oatpp_openssl_configurer_CertificateBuffer_hpp
-
-#include "ContextConfigurer.hpp"
-
-#include "oatpp/core/Types.hpp"
+#include "PeerCertificateVerification.hpp"
+#include <openssl/ssl.h>
 
 namespace oatpp { namespace openssl { namespace configurer {
 
-/**
- * Context configurer for certificate file.
- * @extends &id:oatpp::openssl::configurer::ContextConfigurer;.
- */
-class CertificateBuffer : public ContextConfigurer {
-private:
-  std::shared_ptr<X509> m_certificate;
-public:
+PeerCertificateVerification::PeerCertificateVerification(CertificateVerificationMode mode)
+  : m_mode(mode)
+{}
 
-  /**
-   * Constructor.
-   * @param certificateBuffer
-   * @param certificateBufferLength
-   */
-  CertificateBuffer(const void *certificateBuffer, int certificateBufferLength);
-  CertificateBuffer(const std::string& certificateBuffer);
+static int toSslVerify(CertificateVerificationMode mode) {
+  switch (mode) {
+    case CertificateVerificationMode::EnabledStrong:
+      return SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+    case CertificateVerificationMode::EnabledWeak:
+      return SSL_VERIFY_PEER;
+    case CertificateVerificationMode::Disabled:
+      return SSL_VERIFY_NONE;
+  }
+}
 
-  void configure(SSL_CTX* ctx) override;
-
-};
+void PeerCertificateVerification::configure(SSL_CTX *ctx) {
+  SSL_CTX_set_verify(ctx, toSslVerify(m_mode), nullptr);
+}
 
 }}}
-
-#endif // oatpp_openssl_configurer_CertificateBuffer_hpp

--- a/src/oatpp-openssl/configurer/PeerCertificateVerification.hpp
+++ b/src/oatpp-openssl/configurer/PeerCertificateVerification.hpp
@@ -22,8 +22,8 @@
  *
  ***************************************************************************/
 
-#ifndef oatpp_openssl_configurer_CertificateBuffer_hpp
-#define oatpp_openssl_configurer_CertificateBuffer_hpp
+#ifndef oatpp_openssl_configurer_VerifyPeer_hpp
+#define oatpp_openssl_configurer_VerifyPeer_hpp
 
 #include "ContextConfigurer.hpp"
 
@@ -31,22 +31,26 @@
 
 namespace oatpp { namespace openssl { namespace configurer {
 
+enum class CertificateVerificationMode {
+  EnabledStrong, // A peer certificate is validated and MUST be presented
+  EnabledWeak, // A peer certificate is validated IF it is presented
+  Disabled, // No verification of peer certificate
+};
+
 /**
- * Context configurer for certificate file.
+ * Context configurer for setting peer certificate verification policy for the TLS connection
  * @extends &id:oatpp::openssl::configurer::ContextConfigurer;.
  */
-class CertificateBuffer : public ContextConfigurer {
+class PeerCertificateVerification : public ContextConfigurer {
 private:
-  std::shared_ptr<X509> m_certificate;
+    CertificateVerificationMode m_mode;
 public:
 
   /**
    * Constructor.
-   * @param certificateBuffer
-   * @param certificateBufferLength
+   * @param state
    */
-  CertificateBuffer(const void *certificateBuffer, int certificateBufferLength);
-  CertificateBuffer(const std::string& certificateBuffer);
+  PeerCertificateVerification(CertificateVerificationMode state);
 
   void configure(SSL_CTX* ctx) override;
 
@@ -54,4 +58,4 @@ public:
 
 }}}
 
-#endif // oatpp_openssl_configurer_CertificateBuffer_hpp
+#endif // oatpp_openssl_configurer_VerifyPeer_hpp

--- a/src/oatpp-openssl/configurer/PrivateKeyBuffer.cpp
+++ b/src/oatpp-openssl/configurer/PrivateKeyBuffer.cpp
@@ -22,12 +22,13 @@
  *
  ***************************************************************************/
 
+#include <openssl/err.h>
 #include "PrivateKeyBuffer.hpp"
 
 namespace oatpp { namespace openssl { namespace configurer {
 
-PrivateKeyBuffer::PrivateKeyBuffer(const std::string& privateKeyBuffer)
-  : PrivateKeyBuffer::PrivateKeyBuffer(privateKeyBuffer.data(), privateKeyBuffer.size())
+PrivateKeyBuffer::PrivateKeyBuffer(const oatpp::String& privateKeyBuffer)
+  : PrivateKeyBuffer::PrivateKeyBuffer(privateKeyBuffer->data(), privateKeyBuffer->size())
 {}
 
 PrivateKeyBuffer::PrivateKeyBuffer(const void *privateKeyBuffer, int privateKeyBufferLength)
@@ -36,10 +37,15 @@ PrivateKeyBuffer::PrivateKeyBuffer(const void *privateKeyBuffer, int privateKeyB
     return;
   }
   auto buffer = std::shared_ptr<BIO>(BIO_new_mem_buf(privateKeyBuffer, privateKeyBufferLength), BIO_free);
+  if (buffer == nullptr) {
+    throw std::runtime_error("[oatpp::openssl::configurer::PrivateKeyBuffer::PrivateKeyBuffer()]: Error. BIO_new_mem_buf(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
+  }
+
   m_privateKey = std::shared_ptr<EVP_PKEY>(PEM_read_bio_PrivateKey(buffer.get(), nullptr, nullptr, nullptr), EVP_PKEY_free);
   if (m_privateKey == nullptr) {
-    throw std::runtime_error("[oatpp::openssl::configurer::PrivateKeyBuffer::PrivateKeyBuffer()]: Error. "
-                             "'m_privateKey' == nullptr.");
+    throw std::runtime_error("[oatpp::openssl::configurer::PrivateKeyBuffer::PrivateKeyBuffer()]: Error. PEM_read_bio_PrivateKey(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
   }
 }
 
@@ -48,8 +54,8 @@ void PrivateKeyBuffer::configure(SSL_CTX *ctx) {
     return;
   }
   if (SSL_CTX_use_PrivateKey(ctx, m_privateKey.get()) <= 0) {
-    throw std::runtime_error("[oatpp::openssl::configurer::PrivateKeyBuffer::configure()]: Error. "
-                             "Call to 'SSL_CTX_use_PrivateKey' failed.");
+    throw std::runtime_error("[oatpp::openssl::configurer::PrivateKeyBuffer::configure()]: Error. SSL_CTX_use_PrivateKey(): "
+                             + std::string(ERR_error_string(ERR_get_error(), nullptr)));
   }
 }
 

--- a/src/oatpp-openssl/configurer/PrivateKeyBuffer.hpp
+++ b/src/oatpp-openssl/configurer/PrivateKeyBuffer.hpp
@@ -46,6 +46,7 @@ public:
    * @param privateKeyBufferLength
    */
   PrivateKeyBuffer(const void *privateKeyBuffer, int privateKeyBufferLength);
+  PrivateKeyBuffer(const std::string& privateKeyBuffer);
 
   void configure(SSL_CTX* ctx) override;
 

--- a/src/oatpp-openssl/configurer/PrivateKeyBuffer.hpp
+++ b/src/oatpp-openssl/configurer/PrivateKeyBuffer.hpp
@@ -46,7 +46,7 @@ public:
    * @param privateKeyBufferLength
    */
   PrivateKeyBuffer(const void *privateKeyBuffer, int privateKeyBufferLength);
-  PrivateKeyBuffer(const std::string& privateKeyBuffer);
+  PrivateKeyBuffer(const oatpp::String& privateKeyBuffer);
 
   void configure(SSL_CTX* ctx) override;
 


### PR DESCRIPTION
Fixes issues with the buffered configured api:
* Handle empty buffers as a no-op
* Rewrite of CertificateChainBuffer because the old implementation was not consistent with CertificateChainFile

New features:
* Adds a ca certificate bundle configurer
* Adds a certificate verification mode configurer